### PR TITLE
Increase login password length requirement

### DIFF
--- a/src/core/http/api/auth.ts
+++ b/src/core/http/api/auth.ts
@@ -46,9 +46,10 @@ export function createAuthRoutes(app: CoreSaaSApp) {
     method: 'POST',
     path: '/auth/login',
     handler: async ({ body }) => {
-      const schema = z.object({ 
-        email: z.string().email(), 
-        password: z.string().min(6) 
+      const schema = z.object({
+        email: z.string().email(),
+        // Require passwords to be at least 8 characters
+        password: z.string().min(8)
       });
       
       try {

--- a/src/tests/e2e.auth.test.ts
+++ b/src/tests/e2e.auth.test.ts
@@ -339,7 +339,7 @@ describe('E2E: Authentication', () => {
       expect(invalidEmailRes.statusCode).toBe(200);
       expect(invalidEmailRes.json()).toHaveProperty('error', 'Invalid input');
 
-      // Test short password
+      // Test short password (less than 8 characters)
       const shortPasswordRes = await f.inject({ 
         method: 'POST', 
         url: '/auth/login', 


### PR DESCRIPTION
## Summary
- require passwords to be at least 8 characters when logging in
- clarify password length requirement in login test

## Testing
- `npm run build` *(fails: Property 'grantUserPermission' does not exist on type 'CoreSaaSApp')*
- `npm test` *(fails: Validation failed; Foreign key constraint violated on the foreign key)*

------
https://chatgpt.com/codex/tasks/task_e_689ff03cc0ec832aa7308df679368060