### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -36,7 +36,12 @@ async function checkAccess(argv: minimist.ParsedArgs) {
   const permission = String(argv.permission || argv.p || 'example:read');
   const app = getApp();
   await app.permissionRegistry.initFromDatabase();
-  app.grantUserPermission(userId, permission, contextId);
+  await app.permissionService.grantToUser({
+    userId,
+    permissionKey: permission,
+    contextId,
+    context: { actorId: 'system' }
+  });
   const ok = await app.checkAccess({ userId, context: contextId ? { id: contextId, type: 'unknown' } : null, permission });
   // eslint-disable-next-line no-console
   console.log(ok ? 'ALLOWED' : 'DENIED');

--- a/src/core/http/authorize.ts
+++ b/src/core/http/authorize.ts
@@ -40,7 +40,7 @@ export function createAuthorize(app: CoreSaaSApp, requiredPermission: string, op
         r => r?.query?.['contextType'],
         r => r?.body?.contextType
       ]);
-      const contextType = requestContextType ?? options.contextType ?? null;
+      const contextType = requestContextType ?? options.contextType;
 
       if (!userId) {
         return respond(res, next, 401, { statusCode: 401, message: 'Unauthorized' });

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -20,7 +20,12 @@ async function bootstrap() {
     handler: async ({ user, context }) => ({ user, context, ok: true }),
   });
 
-  app.grantUserPermission('user_123', 'example:*', 'ctx_1');
+  await app.permissionService.grantToUser({
+    userId: 'user_123',
+    permissionKey: 'example:*',
+    contextId: 'ctx_1',
+    context: { actorId: 'system' }
+  });
 
   await app.listen(Number(process.env.PORT) || 3000);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export interface LatticePlugin {
 
 export interface CheckAccessInput {
   userId: string;
-  context?: { type: string; id: string } | null;
+  context?: { type: string; id: string | null } | null;
   permission: string;
   scope?: 'exact' | 'global' | 'type-wide';
   contextType?: string;
@@ -187,11 +187,16 @@ export class CoreSaaSApp {
   public async checkAccess(input: CheckAccessInput): Promise<boolean> {
     const { userId, context, permission, scope, contextType } = input;
 
-    let lookupContext = context ?? null;
+    let lookupContext: { type: string; id: string | null } | null = context ?? null;
     if (scope === 'global') {
       lookupContext = null;
     } else if (scope === 'type-wide') {
-      lookupContext = contextType ? { type: contextType, id: null } : context;
+      const type = contextType ?? context?.type;
+      if (type) {
+        lookupContext = { type, id: null };
+      } else {
+        lookupContext = null;
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- use PermissionService.grantToUser in CLI and dev bootstrap instead of removed grantUserPermission
- handle context type in authorize middleware without null to satisfy CheckAccessInput
- allow null context IDs in checkAccess and update lookup logic for type-wide scopes

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff39da7f0832a953faf464ba6f896