### PR TITLE
refactor: remove unused PrismaClient import

### DIFF
--- a/src/core/services/service-factory.ts
+++ b/src/core/services/service-factory.ts
@@ -13,7 +13,6 @@
  * - Testing support with reset capabilities
  */
 
-import { db as PrismaClient } from '../db/db-client';
 import type { PrismaClient as PrismaClientType } from '../../../prisma/generated/client';
 import { AuditService, type AuditConfig } from './audit-service';
 import { ContextService } from './context-service';


### PR DESCRIPTION
## Summary
- remove unused db client import from service factory

## Testing
- `npm run test:minimal` (fails: expected false to be true)
- `npm run build` (fails: TS2339 Property 'grantUserPermission' does not exist on type 'CoreSaaSApp')

------
https://chatgpt.com/codex/tasks/task_e_689ff62d15e8832a9c93e89d40fd99ad