### PR TITLE
Use permission service for permission assignments

### DIFF
--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -36,7 +36,12 @@ async function checkAccess(argv: minimist.ParsedArgs) {
   const permission = String(argv.permission || argv.p || 'example:read');
   const app = getApp();
   await app.permissionRegistry.initFromDatabase();
-  app.grantUserPermission(userId, permission, contextId);
+  await app.permissionService.grantToUser({
+    userId,
+    permissionKey: permission,
+    contextId,
+    context: { actorId: 'system' }
+  });
   const ok = await app.checkAccess({ userId, context: contextId ? { id: contextId, type: 'unknown' } : null, permission });
   // eslint-disable-next-line no-console
   console.log(ok ? 'ALLOWED' : 'DENIED');

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -20,7 +20,12 @@ async function bootstrap() {
     handler: async ({ user, context }) => ({ user, context, ok: true }),
   });
 
-  app.grantUserPermission('user_123', 'example:*', 'ctx_1');
+  await app.permissionService.grantToUser({
+    userId: 'user_123',
+    permissionKey: 'example:*',
+    contextId: 'ctx_1',
+    context: { actorId: 'system' }
+  });
 
   await app.listen(Number(process.env.PORT) || 3000);
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `app.grantUserPermission` with `permissionService.grantToUser` in dev bootstrap
- Update CLI `check-access` command to assign permissions through `permissionService`

## Testing
- `npm test` *(fails: Validation failed, audit log foreign key constraint)*

------
https://chatgpt.com/codex/tasks/task_e_689ff612254c832a85abf86632962a42