### PR TITLE
chore(cli): remove unused imports

### DIFF
--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 import minimist from 'minimist';
 import { CoreSaaS } from '../../index';
-import { defaultRoutePermissionPolicy } from '../policy/policy';
-import { PrismaClient } from '@prisma/client';
-import { getServiceFactory } from '../services';
 
 function getApp() {
   const app = CoreSaaS({


### PR DESCRIPTION
## Summary
- remove unused imports from CLI entry point

## Testing
- `npm run build` *(fails: Property 'grantUserPermission' does not exist on type 'CoreSaaSApp'; also type errors in other files)*
- `npm test` *(fails: PrismaClientKnownRequestError: Foreign key constraint violated on AuditLog)*

------
https://chatgpt.com/codex/tasks/task_e_689ff6201830832a935706199e2009d5