### PR TITLE
feat: add configurable API prefix for admin UI integration

### DIFF
--- a/src/core/http/api/auth.ts
+++ b/src/core/http/api/auth.ts
@@ -39,12 +39,14 @@ export function requireAuthMiddleware(app: CoreSaaSApp) {
   };
 }
 
-export function createAuthRoutes(app: CoreSaaSApp) {
+export function createAuthRoutes(app: CoreSaaSApp, prefix: string = '') {
   const jwt = getJwt(app);
+
+  const p = prefix;
 
   app.route({
     method: 'POST',
-    path: '/auth/login',
+    path: `${p}/auth/login`,
     handler: async ({ body }) => {
       const schema = z.object({
         email: z.string().email(),
@@ -79,7 +81,7 @@ export function createAuthRoutes(app: CoreSaaSApp) {
 
   app.route({
     method: 'POST',
-    path: '/auth/refresh',
+    path: `${p}/auth/refresh`,
     handler: async ({ body }) => {
       const schema = z.object({ 
         refreshToken: z.string().min(1) 
@@ -123,7 +125,7 @@ export function createAuthRoutes(app: CoreSaaSApp) {
   // Explicit revocation endpoint
   app.route({
     method: 'POST',
-    path: '/auth/revoke',
+    path: `${p}/auth/revoke`,
     handler: async ({ body }) => {
       const schema = z.object({ 
         token: z.string().min(1) 
@@ -156,7 +158,7 @@ export function createAuthRoutes(app: CoreSaaSApp) {
   // Password change (requires auth)
   app.route({
     method: 'POST',
-    path: '/auth/password/change',
+    path: `${p}/auth/password/change`,
     preHandler: requireAuthMiddleware(app),
     handler: async ({ body, user }) => {
       const schema = z.object({ 
@@ -188,7 +190,7 @@ export function createAuthRoutes(app: CoreSaaSApp) {
   // Password reset request (by email)
   app.route({
     method: 'POST',
-    path: '/auth/password/reset/request',
+    path: `${p}/auth/password/reset/request`,
     handler: async ({ body }) => {
       const schema = z.object({ 
         email: z.string().email() 
@@ -223,7 +225,7 @@ export function createAuthRoutes(app: CoreSaaSApp) {
   // Password reset confirm
   app.route({
     method: 'POST',
-    path: '/auth/password/reset/confirm',
+    path: `${p}/auth/password/reset/confirm`,
     handler: async ({ body }) => {
       const schema = z.object({ 
         token: z.string().min(1), 

--- a/src/core/http/api/contexts.ts
+++ b/src/core/http/api/contexts.ts
@@ -2,10 +2,11 @@ import { CoreSaaSApp } from '../../../index';
 import { type RoutePermissionPolicy } from '../../policy/policy';
 import { z } from 'zod';
 
-export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy) {
+export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy, prefix: string = '') {
+  const p = prefix;
   app.route({
     method: 'POST',
-    path: '/contexts',
+    path: `${p}/contexts`,
     preHandler: app.authorize(policy.contexts!.create),
     handler: async ({ body, req }) => {
       const schema = z.object({ 
@@ -35,7 +36,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'GET',
-    path: '/contexts/:id',
+    path: `${p}/contexts/:id`,
     preHandler: app.authorize(policy.contexts!.get),
     handler: async ({ params, req }) => {
       try {
@@ -54,7 +55,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'PUT',
-    path: '/contexts/:id',
+    path: `${p}/contexts/:id`,
     preHandler: app.authorize(policy.contexts!.update),
     handler: async ({ params, body, req }) => {
       const schema = z.object({ 
@@ -81,7 +82,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'DELETE',
-    path: '/contexts/:id',
+    path: `${p}/contexts/:id`,
     preHandler: app.authorize(policy.contexts!.delete),
     handler: async ({ params, req }) => {
       try {
@@ -98,7 +99,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'POST',
-    path: '/contexts/:id/users/add',
+    path: `${p}/contexts/:id/users/add`,
     preHandler: app.authorize(policy.contexts!.addUser),
     handler: async ({ params, body, req }) => {
       const schema = z.object({ 
@@ -126,7 +127,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'POST',
-    path: '/contexts/:id/users/remove',
+    path: `${p}/contexts/:id/users/remove`,
     preHandler: app.authorize(policy.contexts!.removeUser),
     handler: async ({ params, body, req }) => {
       const schema = z.object({ 
@@ -154,7 +155,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'GET',
-    path: '/contexts',
+    path: `${p}/contexts`,
     preHandler: app.authorize(policy.contexts!.get),
     handler: async ({ query, req }) => {
       try {
@@ -178,7 +179,7 @@ export function registerContextRoutes(app: CoreSaaSApp, policy: RoutePermissionP
 
   app.route({
     method: 'GET',
-    path: '/contexts/:id/users',
+    path: `${p}/contexts/:id/users`,
     preHandler: app.authorize(policy.contexts!.get),
     handler: async ({ params, req }) => {
       try {

--- a/src/core/http/api/permissions.ts
+++ b/src/core/http/api/permissions.ts
@@ -2,10 +2,11 @@ import { CoreSaaSApp } from '../../../index';
 import { type RoutePermissionPolicy } from '../../policy/policy';
 import { z } from 'zod';
 
-export function registerPermissionRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy) {
+export function registerPermissionRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy, prefix: string = '') {
+  const p = prefix;
   app.route({
     method: 'POST',
-    path: '/permissions/user/grant',
+    path: `${p}/permissions/user/grant`,
     preHandler: app.authorize(policy.permissions!.grantUser),
     handler: async ({ body, req }) => {
       const schema = z.object({ 
@@ -38,7 +39,7 @@ export function registerPermissionRoutes(app: CoreSaaSApp, policy: RoutePermissi
 
   app.route({
     method: 'POST',
-    path: '/permissions/user/revoke',
+    path: `${p}/permissions/user/revoke`,
     preHandler: app.authorize(policy.permissions!.revokeUser),
     handler: async ({ body, req }) => {
       const schema = z.object({ 
@@ -71,7 +72,7 @@ export function registerPermissionRoutes(app: CoreSaaSApp, policy: RoutePermissi
 
   app.route({
     method: 'GET',
-    path: '/permissions/user/:userId',
+    path: `${p}/permissions/user/:userId`,
     preHandler: app.authorize(policy.permissions!.grantUser),
     handler: async ({ params, query, req }) => {
       try {
@@ -94,7 +95,7 @@ export function registerPermissionRoutes(app: CoreSaaSApp, policy: RoutePermissi
 
   app.route({
     method: 'GET',
-    path: '/permissions/user/:userId/effective',
+    path: `${p}/permissions/user/:userId/effective`,
     preHandler: app.authorize(policy.permissions!.grantUser),
     handler: async ({ params, query, req }) => {
       try {

--- a/src/core/http/api/roles.ts
+++ b/src/core/http/api/roles.ts
@@ -2,10 +2,11 @@ import { CoreSaaSApp } from '../../../index';
 import { type RoutePermissionPolicy } from '../../policy/policy';
 import { z } from 'zod';
 
-export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy) {
+export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy, prefix: string = '') {
+  const p = prefix;
   app.route({
     method: 'POST',
-    path: '/roles',
+    path: `${p}/roles`,
     preHandler: (req: any, res: any, next: () => void) => {
       const { contextType } = req.body;
       return app.authorize(policy.roles!.create.replace('{type}', contextType), { 
@@ -39,7 +40,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'GET',
-    path: '/roles',
+    path: `${p}/roles`,
     preHandler: (req: any, res: any, next: () => void) => {
       const { contextType } = req.query;
       return app.authorize(policy.roles!.list.replace('{type}', contextType || 'team'), { 
@@ -63,7 +64,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'GET',
-    path: '/roles/:name',
+    path: `${p}/roles/:name`,
     preHandler: (req: any, res: any, next: () => void) => {
       const { contextType } = req.query;
       return app.authorize(policy.roles!.get.replace('{type}', contextType || 'team'), { 
@@ -87,7 +88,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'DELETE',
-    path: '/roles/:name',
+    path: `${p}/roles/:name`,
     preHandler: (req: any, res: any, next: () => void) => {
       const { contextType } = req.query;
       return app.authorize(policy.roles!.delete.replace('{type}', contextType || 'team'), { 
@@ -110,7 +111,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'POST',
-    path: '/roles/assign',
+    path: `${p}/roles/assign`,
     preHandler: (req: any, res: any, next: () => void) => {
       const { contextType } = req.body;
       if (!contextType) {
@@ -153,7 +154,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'POST',
-    path: '/roles/remove',
+    path: `${p}/roles/remove`,
     preHandler: (req: any, res: any, next: () => void) => {
       const { contextType } = req.body;
       if (!contextType) {
@@ -196,7 +197,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'POST',
-    path: '/roles/:name/permissions/add',
+    path: `${p}/roles/:name/permissions/add`,
     preHandler: [
       // Must have role management permission for this type
       (req: any, res: any, next: () => void) => {
@@ -287,7 +288,7 @@ export function registerRoleRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'POST',
-    path: '/roles/:name/permissions/remove',
+    path: `${p}/roles/:name/permissions/remove`,
     preHandler: [
       // Must have role management permission for this type
       (req: any, res: any, next: () => void) => {

--- a/src/core/http/api/users.ts
+++ b/src/core/http/api/users.ts
@@ -2,10 +2,11 @@ import { CoreSaaSApp } from '../../../index';
 import { type RoutePermissionPolicy } from '../../policy/policy';
 import { z } from 'zod';
 
-export function registerUserRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy) {
+export function registerUserRoutes(app: CoreSaaSApp, policy: RoutePermissionPolicy, prefix: string = '') {
+  const p = prefix;
   app.route({
     method: 'POST',
-    path: '/users',
+    path: `${p}/users`,
     preHandler: app.authorize(policy.users!.create),
     handler: async ({ body, req }) => {
       const schema = z.object({ 
@@ -33,7 +34,7 @@ export function registerUserRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'GET',
-    path: '/users',
+    path: `${p}/users`,
     preHandler: app.authorize(policy.users!.list),
     handler: async ({ query, req }) => {
       try {
@@ -59,7 +60,7 @@ export function registerUserRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'GET',
-    path: '/users/:id',
+    path: `${p}/users/:id`,
     preHandler: app.authorize(policy.users!.get),
     handler: async ({ params, req }) => {
       try {
@@ -83,7 +84,7 @@ export function registerUserRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'PUT',
-    path: '/users/:id',
+    path: `${p}/users/:id`,
     preHandler: app.authorize(policy.users!.update),
     handler: async ({ params, body, req }) => {
       const schema = z.object({ 
@@ -110,7 +111,7 @@ export function registerUserRoutes(app: CoreSaaSApp, policy: RoutePermissionPoli
 
   app.route({
     method: 'DELETE',
-    path: '/users/:id',
+    path: `${p}/users/:id`,
     preHandler: app.authorize(policy.users!.delete),
     handler: async ({ params, req }) => {
       try {

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -7,6 +7,7 @@ async function bootstrap() {
     db: { provider: 'sqlite' },
     adapter: (process.env.ADAPTER as 'fastify' | 'express') || 'express',
     jwt: { accessTTL: '15m', refreshTTL: '7d', secret: process.env.JWT_SECRET || 'dev-secret' },
+    apiPrefix: '/api',
   });
 
   // Get the underlying Express app for static file serving
@@ -28,7 +29,7 @@ async function bootstrap() {
     handler: async () => ({ 
       message: 'Lattice Access Control System',
       admin: '/admin',
-      api: '/api',
+      api: app.apiBase || '/api',
       health: '/ping'
     }),
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export interface CoreConfig {
   adapter: SupportedAdapter;
   jwt: { accessTTL: string; refreshTTL: string; secret?: string };
   policy?: RoutePermissionPolicy;
+  apiPrefix?: string;
 }
 
 export interface RouteDefinition<Body = unknown> {
@@ -69,9 +70,11 @@ export class CoreSaaSApp {
   private readonly policy: RoutePermissionPolicy;
   private readonly serviceFactory: ServiceFactory;
   private readonly config: CoreConfig;
+  private readonly apiPrefix: string;
 
   constructor(config: CoreConfig) {
     this.config = config;
+    this.apiPrefix = config.apiPrefix ?? '';
     this.permissionRegistry = new PermissionRegistry();
     this.PermissionRegistry = this.permissionRegistry;
     this.adapterKind = config.adapter;
@@ -106,6 +109,10 @@ export class CoreSaaSApp {
    */
   public get services(): ServiceFactory {
     return this.serviceFactory;
+  }
+
+  public get apiBase() {
+    return this.apiPrefix;
   }
 
   /**
@@ -199,11 +206,11 @@ export class CoreSaaSApp {
     
     // Global request context middleware (only for adapters that support preHandler arrays at route-level)
     // Developers should add it before their own routes if using adapter directly.
-    createAuthRoutes(this);
-    registerUserRoutes(this, this.policy);
-    registerPermissionRoutes(this, this.policy);
-    registerContextRoutes(this, this.policy);
-    registerRoleRoutes(this, this.policy);
+    createAuthRoutes(this, this.apiPrefix);
+    registerUserRoutes(this, this.policy, this.apiPrefix);
+    registerPermissionRoutes(this, this.policy, this.apiPrefix);
+    registerContextRoutes(this, this.policy, this.apiPrefix);
+    registerRoleRoutes(this, this.policy, this.apiPrefix);
     
     await this.httpAdapter.listen(port, host);
   }


### PR DESCRIPTION
## Summary
- allow CoreSaaS to register built-in API routes under a configurable prefix
- expose apiBase and configure dev server to mount routes at `/api`
- update route modules to respect API prefix for admin UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01ee05260832a902197eac5cb2754