### PR TITLE
feat: add resend email adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "fastify": "^5.5.0",
         "jsonwebtoken": "^9.0.2",
         "minimist": "^1.2.8",
+        "resend": "^6.0.1",
         "swagger-autogen": "^2.23.7",
-        "swagger-ui-express": "^5.0.1",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -32,7 +32,6 @@
         "@types/jsonwebtoken": "^9.0.6",
         "@types/minimist": "^1.2.5",
         "@types/node": "^20.14.9",
-        "@types/swagger-ui-express": "^4.1.8",
         "fast-glob": "^3.3.2",
         "prisma": "^6.14.0",
         "ts-node": "^10.9.2",
@@ -1215,13 +1214,6 @@
         "win32"
       ]
     },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1432,17 +1424,6 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/swagger-ui-express": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
-      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/serve-static": "*"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -4086,6 +4067,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.0.1.tgz",
+      "integrity": "sha512-xNZ0gKAOqQcH83lXsqNOwBbpKROnsZpQr9mXRdG6hrHTF9G9Il2pkoTRtq7rJzXMvCZX+I79oahsbSeaYOWRFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4719,30 +4717,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.1.tgz",
-      "integrity": "sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
-      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=5.0.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/thread-stream": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fastify": "^5.5.0",
     "jsonwebtoken": "^9.0.2",
     "minimist": "^1.2.8",
+    "resend": "^6.0.1",
     "swagger-autogen": "^2.23.7",
     "zod": "^3.23.8"
   },

--- a/src/core/services/email-adapter.ts
+++ b/src/core/services/email-adapter.ts
@@ -1,0 +1,18 @@
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  html?: string;
+  text?: string;
+}
+
+export interface EmailAdapter {
+  send(message: EmailMessage): Promise<void>;
+}
+
+import { logger } from '../logger';
+
+export class ConsoleEmailAdapter implements EmailAdapter {
+  async send(message: EmailMessage): Promise<void> {
+    logger.log(`Sending email to ${message.to}: ${message.subject}`);
+  }
+}

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -26,6 +26,12 @@ export type {
   IServiceFactory,
 } from './interfaces';
 
+// Email adapters
+// Export email adapter interfaces and implementations
+export type { EmailAdapter, EmailMessage } from './email-adapter';
+export { ConsoleEmailAdapter } from './email-adapter';
+export { ResendEmailAdapter, type ResendConfig } from './resend-email-adapter';
+
 // Service implementations
 // Exports the concrete service classes that implement the interfaces
 // Each service extends BaseService and provides specific business logic

--- a/src/core/services/resend-email-adapter.ts
+++ b/src/core/services/resend-email-adapter.ts
@@ -1,0 +1,27 @@
+import { Resend } from 'resend';
+import type { EmailAdapter, EmailMessage } from './email-adapter';
+
+export interface ResendConfig {
+  apiKey: string;
+  from: string;
+}
+
+export class ResendEmailAdapter implements EmailAdapter {
+  private resend: Resend;
+  private from: string;
+
+  constructor(config: ResendConfig) {
+    this.resend = new Resend(config.apiKey);
+    this.from = config.from;
+  }
+
+  async send(message: EmailMessage): Promise<void> {
+    await this.resend.emails.send({
+      from: this.from,
+      to: message.to,
+      subject: message.subject,
+      html: message.html,
+      text: message.text,
+    });
+  }
+}

--- a/src/core/services/service-factory.ts
+++ b/src/core/services/service-factory.ts
@@ -19,6 +19,7 @@ import { RoleService } from './role-service';
 import { UserPermissionService } from './user-permission-service';
 import { UserService } from './user-service';
 import { IServiceFactory, type IUserService, type IRoleService, type IPermissionService, type IContextService } from './interfaces';
+import type { EmailAdapter } from './email-adapter';
 
 /**
  * Configuration interface for ServiceFactory
@@ -29,6 +30,8 @@ import { IServiceFactory, type IUserService, type IRoleService, type IPermission
 export interface ServiceFactoryConfig {
   /** Database client instance for all services */
   db: PrismaClientType;
+  /** Optional email adapter for services that send emails */
+  emailAdapter?: EmailAdapter;
 }
 
 /**
@@ -45,6 +48,9 @@ export interface ServiceFactoryConfig {
 export class ServiceFactory implements IServiceFactory {
   /** Database client shared across all services */
   private readonly db: PrismaClientType;
+
+  /** Optional email adapter */
+  private readonly emailAdapter?: EmailAdapter;
   
   /** Lazy-loaded context service instance */
   private _contextService?: ContextService;
@@ -64,6 +70,7 @@ export class ServiceFactory implements IServiceFactory {
    */
   constructor(config: ServiceFactoryConfig) {
     this.db = config.db;
+    this.emailAdapter = config.emailAdapter;
   }
 
   /**
@@ -125,7 +132,7 @@ export class ServiceFactory implements IServiceFactory {
    */
   getUserService(): IUserService {
     if (!this._userService) {
-      this._userService = new UserService(this.db);
+      this._userService = new UserService(this.db, this.emailAdapter);
     }
     return this._userService;
   }

--- a/src/core/services/user-service.ts
+++ b/src/core/services/user-service.ts
@@ -17,6 +17,7 @@ import type { User } from '../db/db-client';
 import { hash, compare } from 'bcryptjs';
 import { randomUUID } from 'crypto';
 import { logger } from '../logger';
+import type { EmailAdapter } from './email-adapter';
 
 /**
  * UserService Class
@@ -25,9 +26,11 @@ import { logger } from '../logger';
  * operations. Extends BaseService to inherit common functionality.
  */
 export class UserService extends BaseService implements IUserService {
+  private readonly emailAdapter?: EmailAdapter;
 
-  constructor(db: any) {
+  constructor(db: any, emailAdapter?: EmailAdapter) {
     super(db);
+    this.emailAdapter = emailAdapter;
   }
   
   /**
@@ -422,9 +425,18 @@ export class UserService extends BaseService implements IUserService {
           },
         });
 
-        // TODO: Send email with reset link
-        // This would typically integrate with an email service
-        logger.log(`Password reset token for ${email}: ${resetToken}`);
+        // Send email with reset link
+        if (this.emailAdapter) {
+          const resetLink = `${process.env.APP_BASE_URL ?? ''}/reset-password?token=${resetToken}`;
+          await this.emailAdapter.send({
+            to: email,
+            subject: 'Password Reset',
+            html: `<p>Click <a href="${resetLink}">here</a> to reset your password.</p>`,
+            text: `Reset your password: ${resetLink}`,
+          });
+        } else {
+          logger.log(`Password reset token for ${email}: ${resetToken}`);
+        }
       },
       {
         action: 'user.password_reset_initiated',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { registerContextRoutes } from './core/http/api/contexts';
 import { registerRoleRoutes } from './core/http/api/roles';
 import { defaultRoutePermissionPolicy, type RoutePermissionPolicy } from './core/policy/policy';
 import { ServiceFactory, getServiceFactory, setServiceFactory } from './core/services';
+import type { EmailAdapter } from './core/services';
 import { db } from './core/db/db-client';
 import { logger } from './core/logger';
 
@@ -21,6 +22,7 @@ export interface CoreConfig {
   jwt: { accessTTL: string; refreshTTL: string; secret?: string };
   policy?: RoutePermissionPolicy;
   apiPrefix?: string;
+  emailAdapter?: EmailAdapter;
 }
 
 export interface RouteDefinition<Body = unknown> {
@@ -91,7 +93,8 @@ export class CoreSaaSApp {
 
     // Initialize service factory with configuration
     this.serviceFactory = new ServiceFactory({
-      db
+      db,
+      emailAdapter: config.emailAdapter,
     });
 
     // Set global service factory for application-wide access
@@ -247,5 +250,12 @@ export function CoreSaaS(config: CoreConfig): CoreSaaSApp {
 }
 
 export type { PermissionRegistry };
+
+export {
+  ResendEmailAdapter,
+  ConsoleEmailAdapter,
+  type EmailAdapter,
+  type EmailMessage,
+} from './core/services';
 
 

--- a/src/tests/reset-password-email.test.ts
+++ b/src/tests/reset-password-email.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { UserService } from '../core/services/user-service';
+import { db } from '../core/db/db-client';
+import type { EmailAdapter, EmailMessage } from '../core/services/email-adapter';
+
+class MockEmailAdapter implements EmailAdapter {
+  public sent: EmailMessage[] = [];
+  async send(message: EmailMessage): Promise<void> {
+    this.sent.push(message);
+  }
+}
+
+describe('UserService resetPassword', () => {
+  let service: UserService;
+  let mock: MockEmailAdapter;
+
+  beforeAll(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
+  });
+
+  beforeEach(async () => {
+    mock = new MockEmailAdapter();
+    service = new UserService(db, mock);
+
+    await db.passwordResetToken.deleteMany();
+    await db.user.deleteMany();
+
+    await db.user.create({
+      data: {
+        id: 'u1',
+        email: 'test@example.com',
+        passwordHash: 'hash',
+      },
+    });
+  });
+
+  it('sends an email with reset token', async () => {
+    await service.resetPassword('test@example.com');
+    expect(mock.sent.length).toBe(1);
+    expect(mock.sent[0].to).toBe('test@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add pluggable email adapter interface with default console implementation
- implement Resend adapter and wire into ServiceFactory and UserService
- expose adapter through CoreConfig and add password reset email test

## Testing
- `npm run test:minimal --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a2382bde40832a88956cc2aebe4019