### PR TITLE
chore: remove context hierarchy remnants

### DIFF
--- a/src/core/services/context-service.ts
+++ b/src/core/services/context-service.ts
@@ -324,37 +324,6 @@ export class ContextService extends BaseService implements IContextService {
       serviceContext
     );
   }
-
-  async getContextHierarchy(contextId: string, context?: ServiceContext): Promise<{
-    current: Context;
-    parents: Context[];
-    children: Context[];
-  }> {
-    this.validateString(contextId, 'context id');
-
-    return this.execute(
-      async () => {
-        const current = await this.db.context.findUnique({ where: { id: contextId } });
-        if (!current) {
-          throw ServiceError.notFound('Context', contextId);
-        }
-
-        // For now, return empty arrays for parents and children
-        // This can be extended when hierarchical contexts are implemented
-        return {
-          current,
-          parents: [],
-          children: [],
-        };
-      },
-      {
-        action: 'context.hierarchy.read',
-        success: true,
-        contextId,
-      },
-      context
-    );
-  }
 }
 
 

--- a/src/core/services/interfaces.ts
+++ b/src/core/services/interfaces.ts
@@ -384,7 +384,6 @@ export interface IPermissionService {
  * - Context resolution from requests
  * - Context creation and management
  * - User membership in contexts
- * - Context hierarchy management
  */
 export interface IContextService {
   /**


### PR DESCRIPTION
## Summary
- remove unused getContextHierarchy method
- drop context hierarchy reference from interface docs

## Testing
- `npm test` *(fails: The table `main.UserPermission` does not exist in the current database.)*

------
https://chatgpt.com/codex/tasks/task_e_68a3514c9148832a95416e85d610909d