### PR TITLE
refactor: use wildcard re-exports for services

### DIFF
--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -13,37 +13,25 @@
 
 // Base service infrastructure
 // Exports the foundational classes and interfaces that all services extend
-export { BaseService, ServiceError, type ServiceContext } from './base-service';
+export * from './base-service';
 
 // Service interfaces
 // Exports TypeScript interfaces that define contracts for all services
 // These interfaces enable type safety, testing, and clear API documentation
-export type {
-  IUserService,
-  IRoleService,
-  IPermissionService,
-  IContextService,
-  IServiceFactory,
-} from './interfaces';
+export * from './interfaces';
 
 // Service implementations
 // Exports the concrete service classes that implement the interfaces
 // Each service extends BaseService and provides specific business logic
-export { ContextService, type ResolveContextInput, type ContextObject } from './context-service';
-export { RoleService } from './role-service';
-export { UserPermissionService } from './user-permission-service';
-export { UserService } from './user-service';
+export * from './context-service';
+export * from './role-service';
+export * from './user-permission-service';
+export * from './user-service';
 
 // Service factory
 // Exports the factory pattern implementation for creating and managing services
 // The factory provides dependency injection, lazy loading, and lifecycle management
-export { 
-  ServiceFactory, 
-  type ServiceFactoryConfig,
-  getServiceFactory,
-  setServiceFactory,
-  resetServiceFactory,
-} from './service-factory';
+export * from './service-factory';
 
 // Re-export database types for convenience
 // Exports Prisma-generated types and database-related interfaces


### PR DESCRIPTION
## Summary
- simplify core service exports using wildcard barrel re-exports

## Testing
- `npm test` *(fails: The table `main.UserPermission` does not exist in the current database)*

------
https://chatgpt.com/codex/tasks/task_e_68a3511d876c832aa9864ca31123fc11