### PR TITLE
refactor: standardize UserPermission return type

### DIFF
--- a/src/core/services/user-permission-service.ts
+++ b/src/core/services/user-permission-service.ts
@@ -29,8 +29,7 @@
 
 import { BaseService, ServiceError, type ServiceContext } from './base-service';
 import { IPermissionService } from './interfaces';
-import type { Permission } from '../db/db-client';
-import type { Prisma } from '../db/db-client';
+import type { Permission, UserPermission } from '../db/db-client';
 
 /**
  * UserPermissionService Class
@@ -76,7 +75,7 @@ export class UserPermissionService extends BaseService implements IPermissionSer
     contextId?: string | null;
     contextType?: string | null;
     context?: ServiceContext;
-  }): Promise<Prisma.UserPermissionGetPayload<{}>> {
+  }): Promise<UserPermission> {
     const { userId, permissionKey, contextId, contextType, context: serviceContext } = params;
 
     // Validate required inputs
@@ -640,7 +639,7 @@ export class UserPermissionService extends BaseService implements IPermissionSer
       contextType?: string | null;
     }>;
     context?: ServiceContext;
-  }): Promise<Prisma.UserPermissionGetPayload<{}>[]> {
+  }): Promise<UserPermission[]> {
     const { userId, permissions, context: serviceContext } = params;
 
     // Validate required inputs
@@ -657,7 +656,7 @@ export class UserPermissionService extends BaseService implements IPermissionSer
           throw ServiceError.notFound('User', userId);
         }
 
-        const results: Prisma.UserPermissionGetPayload<{}>[] = [];
+        const results: UserPermission[] = [];
 
         // Use transaction for bulk operations to ensure atomicity
         await this.withTransaction(async (tx) => {


### PR DESCRIPTION
## Summary
- ensure `grantToUser` and bulk grant operations return `UserPermission`
- clean up imports to use shared type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a351032024832a9f2475443aaa4c47