### PR TITLE
Optimize role permission lookup in user permission service

### DIFF
--- a/src/core/services/user-permission-service.ts
+++ b/src/core/services/user-permission-service.ts
@@ -437,14 +437,30 @@ export class UserPermissionService extends BaseService implements IPermissionSer
         });
 
         // Collect all permissions from user's roles
-        const rolePermissions: Permission[] = [];
-        for (const userRole of userRoles) {
-          const permissions = await this.getRolePermissions({
-            roleId: userRole.roleId,
-            contextId,
-            contextType,
+        let rolePermissions: Permission[] = [];
+        const roleIds = userRoles.map((userRole) => userRole.roleId);
+
+        if (roleIds.length > 0) {
+          const where: Prisma.RolePermissionWhereInput = {
+            roleId: { in: roleIds },
+          };
+
+          if (contextId) {
+            where.contextId = contextId;
+          } else if (contextType) {
+            where.contextId = null;
+            where.contextType = contextType;
+          } else {
+            where.contextId = null;
+            where.contextType = null;
+          }
+
+          const rolePermissionRecords = await this.db.rolePermission.findMany({
+            where,
+            include: { permission: true },
           });
-          rolePermissions.push(...permissions);
+
+          rolePermissions = rolePermissionRecords.map((rp: any) => rp.permission);
         }
 
         // Combine and deduplicate permissions


### PR DESCRIPTION
## Summary
- Batch lookup role permissions when computing a user's effective permissions to avoid sequential queries

## Testing
- `npm test` *(fails: The table `main.UserPermission` does not exist in the current database.)*


------
https://chatgpt.com/codex/tasks/task_e_68a35083b1dc832a8b346457db5b4ddf