### PR TITLE
Fix build by importing Prisma namespace

### DIFF
--- a/src/core/services/user-permission-service.ts
+++ b/src/core/services/user-permission-service.ts
@@ -29,7 +29,7 @@
 
 import { BaseService, ServiceError, type ServiceContext } from './base-service';
 import { IPermissionService } from './interfaces';
-import type { Permission, UserPermission } from '../db/db-client';
+import type { Permission, UserPermission, Prisma } from '../db/db-client';
 
 /**
  * UserPermissionService Class


### PR DESCRIPTION
## Summary
- Import Prisma types into user-permission-service to restore TypeScript build

## Testing
- `npm run build`
- `npm test` *(fails: Invalid `db.userPermission.deleteMany()` invocation – table `main.UserPermission` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a36042d22c832a9ee02aeb432ac8a3