### PR TITLE
feat: add default config and optional API exposure

### DIFF
--- a/src/scripts/dev.ts
+++ b/src/scripts/dev.ts
@@ -7,6 +7,7 @@ async function bootstrap() {
     adapter: (process.env.ADAPTER as 'fastify' | 'express') || 'fastify',
     jwt: { accessTTL: '15m', refreshTTL: '7d', secret: process.env.JWT_SECRET || 'dev-secret' },
     apiPrefix: '/api',
+    exposeAPI: true,
   });
 
   app.route({

--- a/src/scripts/policymanager.ts
+++ b/src/scripts/policymanager.ts
@@ -7,6 +7,7 @@ async function main() {
     jwt: { accessTTL: '15m', refreshTTL: '7d', secret: 'dev-secret' },
     authn: false,
     authz: false,
+    exposeAPI: true,
   });
 
   const port = parseInt(process.env.PORT || '3001', 10);

--- a/src/scripts/team-management-demo.ts
+++ b/src/scripts/team-management-demo.ts
@@ -13,7 +13,8 @@ async function main() {
   const app = Lattice({
     db: { provider: 'sqlite' },
     adapter: 'fastify',
-    jwt: { accessTTL: '15m', refreshTTL: '7d', secret: 'demo-secret' }
+    jwt: { accessTTL: '15m', refreshTTL: '7d', secret: 'demo-secret' },
+    exposeAPI: true,
   });
 
   await app.listen(3000);

--- a/src/tests/default-behavior.test.ts
+++ b/src/tests/default-behavior.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Lattice } from '../index';
+
+describe('Lattice default configuration', () => {
+  beforeAll(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
+  });
+
+  it('allows instantiation without config and does not expose API routes by default', async () => {
+    const app = Lattice();
+    await app.listen(0);
+    const res = await app.fastify!.inject({ method: 'POST', url: '/auth/login', payload: {} });
+    expect(res.statusCode).toBe(404);
+    await app.fastify!.close();
+    await app.shutdown();
+  });
+});


### PR DESCRIPTION
## Summary
- allow `Lattice()` to be called without arguments using a default configuration
- add `exposeAPI` flag to control built-in API route registration
- update scripts to opt-in to API exposure
- add regression test for default config behaviour

## Testing
- `DATABASE_URL="file:./dev.db" npm run prisma:push`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36e7d61cc832a9287912a33e5b107