### PR TITLE
Sanitize API logs

### DIFF
--- a/src/core/http/api/auth.ts
+++ b/src/core/http/api/auth.ts
@@ -12,12 +12,10 @@ function getJwt(app: LatticeCore) {
 
 export function requireAuthMiddleware(app: LatticeCore) {
   return async function (req: any, res: any, next?: (err?: any) => void) {
-    logger.log('🔑 [REQUIRE_AUTH] ===== REQUIRE AUTH MIDDLEWARE CALLED =====');
-    logger.log('🔑 [REQUIRE_AUTH] Request headers:', req?.headers);
-    
+    logger.log('🔑 [REQUIRE_AUTH] Middleware invoked');
+
     try {
       const auth = req?.headers?.authorization as string | undefined;
-      logger.log('🔑 [REQUIRE_AUTH] Authorization header:', auth);
       
       if (!auth || !auth.startsWith('Bearer ')) {
         logger.log('🔑 [REQUIRE_AUTH] ❌ No Bearer token found');
@@ -30,13 +28,11 @@ export function requireAuthMiddleware(app: LatticeCore) {
       }
       
       const token = auth.substring('Bearer '.length);
-      logger.log('🔑 [REQUIRE_AUTH] Token extracted:', token.substring(0, 20) + '...');
-      
+
       const jwt = getJwt(app);
       const payload = await jwt.verify(token);
-      logger.log('🔑 [REQUIRE_AUTH] JWT payload:', payload);
       (req as any).user = { id: payload.sub };
-      logger.log('🔑 [REQUIRE_AUTH] ✅ Set req.user to:', req.user);
+      logger.log('🔑 [REQUIRE_AUTH] ✅ Authenticated user', { userId: payload.sub });
       
       if (next) return next();
     } catch (e) {

--- a/src/core/http/api/roles.ts
+++ b/src/core/http/api/roles.ts
@@ -306,7 +306,11 @@ export function registerRoleRoutes(app: LatticeCore, prefix: string = '') {
       });
       
       const parsed = schema.safeParse(body);
-      logger.log('Validation result:', { success: parsed.success, body, issues: parsed.error?.issues });
+      logger.log('Validation result:', {
+        success: parsed.success,
+        issueCount: parsed.error?.issues?.length ?? 0,
+        userId: req?.user?.id,
+      });
       if (!parsed.success) {
         const error = new Error('Validation failed');
         (error as any).statusCode = 400;

--- a/src/core/http/api/users.ts
+++ b/src/core/http/api/users.ts
@@ -40,14 +40,11 @@ export function registerUserRoutes(app: LatticeCore, prefix: string = '') {
     path: `${p}/users`,
     ...(listPre && { preHandler: listPre }),
     handler: async ({ query, req }) => {
-      logger.log('👥 [USERS_ROUTE] ===== GET /users ROUTE HANDLER CALLED =====');
-      logger.log('👥 [USERS_ROUTE] Query params:', query);
-      logger.log('👥 [USERS_ROUTE] Request user:', req?.user);
-      
+      const limit = query.limit ? parseInt(query.limit as string) : undefined;
+      const offset = query.offset ? parseInt(query.offset as string) : undefined;
+      logger.log('👥 [USERS_ROUTE] Listing users', { userId: req?.user?.id, limit, offset });
+
       try {
-        const limit = query.limit ? parseInt(query.limit as string) : undefined;
-        const offset = query.offset ? parseInt(query.offset as string) : undefined;
-        
         const result = await app.userService.listUsers({
           limit,
           offset,


### PR DESCRIPTION
## Summary
- remove sensitive tokens and headers from auth middleware logs
- log minimal metadata for user listing and role validation

## Testing
- `npm test` *(fails: table `main.UserPermission` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f865df8832aa5c17cf36300f28b