### PR TITLE
Ensure Prisma client disconnects on shutdown

### DIFF
--- a/src/core/services/service-factory.ts
+++ b/src/core/services/service-factory.ts
@@ -179,8 +179,8 @@ export class ServiceFactory implements IServiceFactory {
    * @returns Promise that resolves when all services are shut down
    */
   async shutdown(): Promise<void> {
-    // Add service shutdown logic here as needed
-    await Promise.resolve();
+    // Disconnect the database client
+    await this.db.$disconnect();
   }
 
   /**

--- a/src/tests/shutdown.test.ts
+++ b/src/tests/shutdown.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ServiceFactory } from '../core/services/service-factory';
+import { Lattice } from '../index';
+import type { PrismaClient } from '../core/db/db-client';
+
+// Test that ServiceFactory.shutdown disconnects the database client
+
+describe('ServiceFactory.shutdown', () => {
+  it('disconnects the database client', async () => {
+    const db = { $disconnect: vi.fn().mockResolvedValue(undefined) } as unknown as PrismaClient;
+    const factory = new ServiceFactory({ db, permissionRegistry: {} as any });
+    await factory.shutdown();
+    expect(db.$disconnect).toHaveBeenCalled();
+  });
+});
+
+// Test that LatticeCore.shutdown awaits service factory shutdown
+
+describe('LatticeCore.shutdown', () => {
+  it('awaits the service factory shutdown and disconnects the db', async () => {
+    const app = Lattice({
+      db: { provider: 'sqlite' },
+      adapter: 'fastify',
+      jwt: { accessTTL: '15m', refreshTTL: '7d', secret: 'test' },
+    });
+
+    let resolveDisconnect!: () => void;
+    const disconnectMock = vi.fn(() => new Promise<void>((resolve) => {
+      resolveDisconnect = resolve;
+    }));
+
+    // Override the Prisma client's disconnect method
+    (app.db as any).$disconnect = disconnectMock;
+
+    let shutdownComplete = false;
+    const shutdownPromise = app.shutdown().then(() => {
+      shutdownComplete = true;
+    });
+
+    await Promise.resolve();
+    expect(disconnectMock).toHaveBeenCalled();
+    expect(shutdownComplete).toBe(false);
+
+    resolveDisconnect();
+    await shutdownPromise;
+
+    expect(shutdownComplete).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Disconnect Prisma client in `ServiceFactory.shutdown`
- Add tests confirming both `ServiceFactory` and `LatticeCore` invoke client disconnect and wait for completion

## Testing
- `npm test` *(fails: table `main.UserPermission` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f926b34832abf860086799f2765