### PR TITLE
chore: exclude tests and scripts from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "*": ["*"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/tests", "src/scripts"]
 }
 
 


### PR DESCRIPTION
## Summary
- exclude `src/tests` and `src/scripts` from TypeScript compilation output

## Testing
- `npm run build`
- `find dist -name "*test*"`
- `npm test` *(fails: The table `main.AbacPolicy` does not exist in the current database.)*

------
https://chatgpt.com/codex/tasks/task_e_68a38fc17c40832a99cfb4ba46eaf7c3