### PR TITLE
Require explicit DATABASE_URL configuration

### DIFF
--- a/src/core/db/db-client.ts
+++ b/src/core/db/db-client.ts
@@ -1,10 +1,12 @@
 import { PrismaClient } from '../../../prisma/generated/client';
 import { logger } from '../logger';
 
-// Set the database URL if not already set - this must happen before PrismaClient instantiation
-import path from 'path';
-const dbPath = path.resolve(process.cwd(), 'prisma', 'dev.db');
-process.env.DATABASE_URL = process.env.DATABASE_URL || `file:${dbPath}`;
+// Ensure database URL is explicitly provided
+if (!process.env.DATABASE_URL) {
+  const msg = 'DATABASE_URL environment variable is required but was not provided';
+  logger.error(msg);
+  throw new Error(msg);
+}
 
 /**
  * Singleton instance of PrismaClient for application use.

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { createJwtUtil } from '../core/auth/jwt';
 import { Lattice } from '../index';
 import { db } from '../core/db/db-client';
 
 describe('Auth Service', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
   beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 

--- a/src/tests/authz.test.ts
+++ b/src/tests/authz.test.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { Lattice } from '../index';
 import { db } from '../core/db/db-client';
 
 describe('Authorization Middleware', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
-    beforeEach(async () => {
+  beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 
       db: { provider: 'sqlite' }, 

--- a/src/tests/context.test.ts
+++ b/src/tests/context.test.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { Lattice } from '../index';
 import { db } from '../core/db/db-client';
 
 describe('Context Service', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
-    beforeEach(async () => {
+  beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 
       db: { provider: 'sqlite' }, 

--- a/src/tests/e2e.access-flows.test.ts
+++ b/src/tests/e2e.access-flows.test.ts
@@ -1,16 +1,11 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { Lattice } from '../index';
 import { db } from '../core/db/db-client';
 import { requireAuthMiddleware } from '../core/http/api/auth';
 
 describe('E2E: Access Flows', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
-    beforeEach(async () => {
+  beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 
       db: { provider: 'sqlite' }, 

--- a/src/tests/e2e.auth.test.ts
+++ b/src/tests/e2e.auth.test.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { Lattice } from '../index';
 import { db } from '../core/db/db-client';
 import { createAuthRoutes } from '../core/http/api/auth';
 
 describe('E2E: Authentication', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
   beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 

--- a/src/tests/e2e.roles.test.ts
+++ b/src/tests/e2e.roles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { Lattice } from '../index';
 import { registerRoleRoutes } from '../core/http/api/roles';
 import { db } from '../core/db/db-client';
@@ -14,11 +14,6 @@ function authHeaders(userId: string) {
 
 describe('E2E: Role Management', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
   beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({

--- a/src/tests/e2e.routes.test.ts
+++ b/src/tests/e2e.routes.test.ts
@@ -1,14 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach, afterEach } from 'vitest';
 import { Lattice } from '../index';
 import { db } from '../core/db/db-client';
 
 describe('E2E: Protected Routes', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
   beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 

--- a/src/tests/permissions.test.ts
+++ b/src/tests/permissions.test.ts
@@ -1,14 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { Lattice } from '../index';
 import { db, type UserPermission } from '../core/db/db-client';
 
 describe('Permission System', () => {
   let app: ReturnType<typeof Lattice>;
-
-  beforeAll(async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
-  });
-
   beforeEach(async () => {
     // Create fresh app instance for each test
     app = Lattice({ 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,4 @@
+import path from 'path';
+
+const dbPath = path.resolve(__dirname, '../../prisma/dev.db');
+process.env.DATABASE_URL = `file:${dbPath}`;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
     testTimeout: 10000,
     // Disable parallel execution
     threads: false,
+    setupFiles: ['src/tests/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- enforce explicit DATABASE_URL and error if missing
- provide global test setup that sets DATABASE_URL
- clean up tests to rely on global config

## Testing
- `npx prisma db push`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38f7f58b0832aae75ddcd67bb646d