### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/src/core/http/adapters/express-adapter.ts
+++ b/src/core/http/adapters/express-adapter.ts
@@ -21,19 +21,26 @@ export function createExpressAdapter(app: LatticeCore): ExpressHttpAdapter {
   const instance: Express = express();
 
   // Configure CORS
-  instance.use(cors({
-    origin: [
-      'http://localhost:5173', // Vite dev server
-      'http://localhost:3000', // Production admin UI
-      'http://localhost:8080', // Swagger UI
-      'http://127.0.0.1:5173',
-      'http://127.0.0.1:3000',
-      'http://127.0.0.1:8080'
-    ],
-    credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With']
-  }));
+  // Allowed origins can be provided either via the LatticeCore config
+  // (`allowedOrigins`) or through the CORS_ALLOWED_ORIGINS environment
+  // variable (comma-separated).
+  // Example: CORS_ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"
+  // By default, no origins are allowed.
+  const allowedOrigins =
+    ((app as any)?.config?.allowedOrigins as string[] | undefined) ??
+    process.env.CORS_ALLOWED_ORIGINS?.split(',')
+      .map((o) => o.trim())
+      .filter(Boolean) ??
+    [];
+
+  instance.use(
+    cors({
+      origin: allowedOrigins,
+      credentials: true,
+      methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
+    })
+  );
 
   // Configure Express middleware
   instance.use(express.json());

--- a/src/core/http/adapters/fastify-adapter.ts
+++ b/src/core/http/adapters/fastify-adapter.ts
@@ -21,19 +21,25 @@ export function createFastifyAdapter(app: LatticeCore): FastifyHttpAdapter {
     trustProxy: true
   });
 
-  // CORS (from main)
+  // Configure CORS
+  // Allowed origins can be specified via the LatticeCore config
+  // (`allowedOrigins`) or the CORS_ALLOWED_ORIGINS environment variable
+  // (comma-separated).
+  // Example: CORS_ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"
+  // Defaults to an empty array to disallow all cross-origin requests unless
+  // explicitly configured.
+  const allowedOrigins =
+    ((app as any)?.config?.allowedOrigins as string[] | undefined) ??
+    process.env.CORS_ALLOWED_ORIGINS?.split(',')
+      .map((o) => o.trim())
+      .filter(Boolean) ??
+    [];
+
   instance.register(fastifyCors, {
-    origin: [
-      'http://localhost:5173', // Vite dev server
-      'http://localhost:3000', // Production admin UI
-      'http://localhost:8080', // Swagger UI
-      'http://127.0.0.1:5173',
-      'http://127.0.0.1:3000',
-      'http://127.0.0.1:8080'
-    ],
+    origin: allowedOrigins,
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With']
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
   });
 
   // Read the generated swagger spec


### PR DESCRIPTION
## Summary
- allow Express adapter to read CORS origins from config or `CORS_ALLOWED_ORIGINS`
- do the same for Fastify adapter with secure default

## Testing
- `npm run build`
- `npm test` *(fails: The table `main.AbacPolicy` does not exist in the current database)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f7528d0832aa0c02f004da3db36