### PR TITLE
docs: clarify authorization flow

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -137,6 +137,22 @@ await app.policyService.createPolicy({
 - **Condition**: CEL expression that evaluates to true/false
 - **Effect**: `permit` or `deny`
 
+## Authorization Flow
+
+Lattice evaluates every protected request through a layered process:
+
+1. **Route middleware** (`app.routeAuth` or `authorize`): extracts the user ID and context from headers, params, query, or body. It can enforce that a request is global, type-wide, or scoped to an exact context before your handler runs.
+2. **`checkAccess`**: builds the lookup context and loads the user's *effective permissions*—direct grants merged with role‑based permissions. The `PermissionRegistry` checks for the required permission, including wildcard patterns like `users:*`.
+3. **ABAC policies**: if the RBAC check passes, matching Attribute-Based policies are evaluated. Access is granted only when both RBAC and ABAC return `permit`.
+
+Roles are context-aware. Assigning a role in a context whose type doesn't match the role's declared context type results in a validation error, keeping permissions consistent across organizations, teams, and projects.
+
+### Example Scenarios
+
+- **Context-specific role vs. user grant**: A `viewer` role with `example:read` in `ctx_1` allows reads only in that context; a direct grant of `example:write` in `ctx_2` allows writes there.
+- **Context-type validation**: Assigning a role defined for `org` to a `team` context is rejected.
+- **Global and type-wide permissions**: A global permission works across all contexts, while a type-wide permission such as `team:read` applies to every `team` context but not to `org` contexts.
+
 ## Policy Management
 
 ### How Policies Work

--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ app.route({
 
 That's it! Your app now has enterprise-grade authorization without the enterprise complexity.
 
+## 🛡 Authorization Flow
+
+Every protected route goes through a consistent series of checks:
+
+1. **Route middleware** – `app.routeAuth` (or the lower level `authorize` middleware) pulls the user ID and context information from headers, params, query or body. It can enforce that a request is global, type-wide or scoped to an exact context. If any requirement fails the request is rejected before it reaches your handler.
+2. **`checkAccess`** – The app gathers the user's *effective permissions* (direct grants plus those from roles) for the lookup context. The `PermissionRegistry` matches the required permission, honoring wildcard patterns such as `users:*`.
+3. **ABAC policies** – After the RBAC check passes, any Attribute‑Based Access Control policies are evaluated. Access is granted only when both RBAC and ABAC succeed.
+
+Roles are always tied to a context type; assigning a role to a different type is rejected. This ensures your permission model stays consistent across organizations, teams and other boundaries.
+
+### Example scenarios
+
+- **Context-specific role vs. user grant** – A `viewer` role with `example:read` in `ctx_1` allows reading only in that context, while a direct grant of `example:write` in `ctx_2` allows writes there.
+- **Context-type validation** – Assigning a role defined for `org` to a `team` context raises an error.
+- **Global and type-wide permissions** – A global permission works everywhere, whereas a type-wide permission (e.g. `team:read`) covers all contexts of that type.
+
 ## 🧠 Mental Model
 
 In Lattice, every authorization check boils down to:


### PR DESCRIPTION
## Summary
- document authorization middleware, checkAccess, and ABAC flow in README
- detail layered auth flow and sample scenarios in docs

## Testing
- `npm test` *(fails: PrismaClientKnownRequestError: table `main.Permission` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b1db9044832aa8c53a1dd73a436e