### PR TITLE
refactor: consolidate API config

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -283,13 +283,12 @@ const app = Lattice({
     url: process.env.DATABASE_URL 
   },
   adapter: 'fastify', // or 'express'
-  jwt: { 
-    accessTTL: '15m', 
+  jwt: {
+    accessTTL: '15m',
     refreshTTL: '7d',
-    secret: process.env.JWT_SECRET 
+    secret: process.env.JWT_SECRET
   },
-  apiPrefix: '/api/v1',
-  exposeAPI: true // Enable built-in REST APIs
+  apiConfig: { apiPrefix: '/api/v1' } // Built-in REST APIs exposed by default
 });
 
 await app.listen(3000);

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const app = Lattice({
   db: { provider: 'postgres', url: process.env.DATABASE_URL },
   adapter: 'fastify',
   jwt: { accessTTL: '15m', refreshTTL: '7d' },
-  exposeAPI: true
+  apiConfig: { apiPrefix: '/api' }
 });
 
 await app.listen(3000);

--- a/src/scripts/dev.ts
+++ b/src/scripts/dev.ts
@@ -6,8 +6,7 @@ async function bootstrap() {
     db: { provider: 'sqlite' },
     adapter: (process.env.ADAPTER as 'fastify' | 'express') || 'fastify',
     jwt: { accessTTL: '15m', refreshTTL: '7d', secret: process.env.JWT_SECRET || 'dev-secret' },
-    apiPrefix: '/api',
-    exposeAPI: true,
+    apiConfig: { apiPrefix: '/api' },
   });
 
   app.route({
@@ -33,7 +32,7 @@ async function bootstrap() {
   
   logger.log(`🚀 Lattice server running on http://localhost:${port}`);
   logger.log(`📊 Admin UI available at http://localhost:${port}/admin`);
-  logger.log(`🔌 API available at http://localhost:${port}/api`);
+  logger.log(`🔌 API available at http://localhost:${port}${app.apiBase}`);
   logger.log(`📚 API Documentation available at http://localhost:${port}/docs`);
 }
 

--- a/src/scripts/policymanager.ts
+++ b/src/scripts/policymanager.ts
@@ -5,9 +5,7 @@ async function main() {
     db: { provider: 'sqlite' },
     adapter: 'fastify',
     jwt: { accessTTL: '15m', refreshTTL: '7d', secret: 'dev-secret' },
-    authn: false,
-    authz: false,
-    exposeAPI: true,
+    apiConfig: { authn: false, authz: false },
   });
 
   const port = parseInt(process.env.PORT || '3001', 10);

--- a/src/scripts/team-management-demo.ts
+++ b/src/scripts/team-management-demo.ts
@@ -14,7 +14,6 @@ async function main() {
     db: { provider: 'sqlite' },
     adapter: 'fastify',
     jwt: { accessTTL: '15m', refreshTTL: '7d', secret: 'demo-secret' },
-    exposeAPI: true,
   });
 
   await app.listen(3000);

--- a/src/tests/default-behavior.test.ts
+++ b/src/tests/default-behavior.test.ts
@@ -6,11 +6,11 @@ describe('Lattice default configuration', () => {
     process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./dev.db';
   });
 
-  it('allows instantiation without config and does not expose API routes by default', async () => {
+  it('allows instantiation without config and exposes API routes by default', async () => {
     const app = Lattice();
     await app.listen(0);
     const res = await app.fastify!.inject({ method: 'POST', url: '/auth/login', payload: {} });
-    expect(res.statusCode).toBe(404);
+    expect(res.statusCode).toBe(200);
     await app.fastify!.close();
     await app.shutdown();
   });


### PR DESCRIPTION
## Summary
- group API exposure, prefix, and auth toggles into new `apiConfig`
- expose built-in APIs by default
- update example scripts and docs to use `apiConfig.apiPrefix`
- adjust default behavior test for new defaults

## Testing
- `DATABASE_URL=file:./dev.db npm run prisma:push`
- `NODE_OPTIONS=--max_old_space_size=4096 npm run test:minimal`


------
https://chatgpt.com/codex/tasks/task_e_68a4d94d2ae8832a9a994dd5f3cb34ae