### PR TITLE
docs: expand policy management

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -157,6 +157,83 @@ Roles are context-aware. Assigning a role in a context whose type doesn't match 
 
 ## Policy Management
 
+### Route Permission Policy
+
+Every HTTP endpoint exposed by Lattice requires a specific permission.  
+The `defaultRoutePermissionPolicy` describes these defaults:
+
+```ts
+export const defaultRoutePermissionPolicy = {
+  roles: {
+    create: 'roles:{type}:create',
+    list: 'roles:{type}:list',
+    get: 'roles:{type}:read',
+    delete: 'roles:{type}:delete',
+    manage: 'roles:{type}:manage',
+    assign: 'roles:assign:{type}',
+    remove: 'roles:remove:{type}',
+    addPerm: {
+      roleManage: 'roles:{type}:manage',
+      permissionGrant: 'permissions:{perm}:grant:{type}',
+    },
+    removePerm: {
+      roleManage: 'roles:{type}:manage',
+      permissionRevoke: 'permissions:{perm}:revoke:{type}',
+    },
+  },
+  users: {
+    create: 'users:create',
+    list: 'users:read',
+    get: 'users:read',
+    update: 'users:update',
+    delete: 'users:delete',
+  },
+  permissions: {
+    grantUser: 'permissions:grant',
+    revokeUser: 'permissions:revoke',
+  },
+  contexts: {
+    create: 'contexts:create',
+    get: 'contexts:read',
+    update: 'contexts:update',
+    delete: 'contexts:delete',
+    addUser: 'contexts:assign',
+    removeUser: 'contexts:assign',
+  },
+};
+```
+
+You can replace parts of this policy when instantiating `Lattice`:
+
+```ts
+import { Lattice } from 'lattice-core';
+
+const app = Lattice({
+  /* other config */, 
+  policy: {
+    users: { delete: 'users:terminate' }
+  }
+});
+```
+
+For composition outside of the constructor, use the helpers:
+
+```ts
+import {
+  createRoutePermissionPolicy,
+  validateRoutePermissionPolicy,
+} from 'lattice-core';
+
+const policy = createRoutePermissionPolicy({
+  roles: { create: 'roles:{type}:make' }
+});
+
+const errors = validateRoutePermissionPolicy(policy); // []
+```
+
+These helpers merge your overrides with the defaults and check for missing
+permissions, giving you full control over how routes are secured.
+
 ### How Policies Work
 
 Policies in Lattice follow a clear lifecycle:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,45 @@ app.route({
 
 ---
 
+## 🛡️ Policy Management
+
+Lattice protects every built‑in route with a permission rule.  
+The `defaultRoutePermissionPolicy` maps common actions to the permissions they require, like:
+
+```ts
+defaultRoutePermissionPolicy = {
+  roles: { create: 'roles:{type}:create', assign: 'roles:assign:{type}' },
+  users: { list: 'users:read', delete: 'users:delete' },
+  contexts: { create: 'contexts:create', addUser: 'contexts:assign' }
+};
+```
+
+To customize these requirements, pass a partial policy when creating the app.  
+Any fields you provide override the defaults:
+
+```ts
+import { Lattice } from 'lattice-core';
+
+const app = Lattice({
+  /* ... */
+  policy: {
+    users: { list: 'users:list' }
+  }
+});
+```
+
+You can also build a complete policy separately:
+
+```ts
+import { createRoutePermissionPolicy } from 'lattice-core';
+
+const policy = createRoutePermissionPolicy({
+  users: { delete: 'users:terminate' }
+});
+```
+
+---
+
 ## 🤝 Contributing
 
 We’re aiming to make access control less painful and more fun to work with.


### PR DESCRIPTION
## Summary
- document default route permission policy and customization in README
- add detailed route policy management section to main docs

## Testing
- `npm test` *(fails: table `main.UserPermission` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c89e0958832a99e1367151b413ac