### PR TITLE
feat: add policy manager UI

### DIFF
--- a/AccessControlUI/index.html
+++ b/AccessControlUI/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lattice Policy Manager</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="min-h-screen bg-background font-sans antialiased">
+    <div id="root"></div>
+  </body>
+</html>

--- a/AccessControlUI/package.json
+++ b/AccessControlUI/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "lattice-policy-manager-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.0",
+    "lucide-react": "^0.454.0",
+    "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-select": "^1.0.5",
+    "class-variance-authority": "^0.7.0",
+    "@radix-ui/react-slot": "^1.0.2",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^2.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "vite": "^5.0.0",
+    "typescript": "^5.2.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.13"
+  }
+}

--- a/AccessControlUI/postcss.config.js
+++ b/AccessControlUI/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/AccessControlUI/src/App.tsx
+++ b/AccessControlUI/src/App.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './components/ui/tabs';
+import RbacEditor from './components/rbac/RbacEditor';
+import AbacEditor from './components/abac/AbacEditor';
+import { AppShell } from './components/AppShell';
+
+export default function App() {
+  const [tab, setTab] = useState('rbac');
+  return (
+    <AppShell>
+      <Tabs value={tab} onValueChange={setTab} className="w-full">
+        <TabsList>
+          <TabsTrigger value="rbac">RBAC Policy Editor</TabsTrigger>
+          <TabsTrigger value="abac">ABAC Policy Editor</TabsTrigger>
+        </TabsList>
+        <TabsContent value="rbac"><RbacEditor /></TabsContent>
+        <TabsContent value="abac"><AbacEditor /></TabsContent>
+      </Tabs>
+    </AppShell>
+  );
+}

--- a/AccessControlUI/src/components/AppShell.tsx
+++ b/AccessControlUI/src/components/AppShell.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-screen">
+      <aside className="w-60 border-r p-4 space-y-2">
+        <div className="text-xl font-bold">Lattice</div>
+        <nav className="flex flex-col gap-2">
+          <Button variant="ghost" className="justify-start">RBAC</Button>
+          <Button variant="ghost" className="justify-start">ABAC</Button>
+        </nav>
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <header className="border-b p-2 flex items-center gap-2">
+          <Input placeholder="Search" className="w-72" />
+        </header>
+        <main className="flex-1 overflow-auto p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/AccessControlUI/src/components/ConditionAssistant.tsx
+++ b/AccessControlUI/src/components/ConditionAssistant.tsx
@@ -1,0 +1,18 @@
+import { Button } from './ui/button';
+
+const snippets = {
+  ownership: 'resource.owner == user.id',
+  department: 'user.department == resource.department',
+};
+
+export function ConditionAssistant({ onInsert }: { onInsert: (text: string) => void }) {
+  return (
+    <div className="flex gap-2">
+      {Object.entries(snippets).map(([key, snippet]) => (
+        <Button key={key} size="sm" variant="outline" onClick={() => onInsert(snippet)}>
+          {key}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/AccessControlUI/src/components/ContextSelector.tsx
+++ b/AccessControlUI/src/components/ContextSelector.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { Select, SelectTrigger, SelectContent, SelectItem } from './ui/select';
+
+interface Context {
+  id: string;
+  type: string;
+  name: string;
+}
+
+export function ContextSelector({ value, onChange }: { value: string; onChange: (val: string) => void }) {
+  const [contexts, setContexts] = useState<Context[]>([]);
+  useEffect(() => {
+    fetch('/api/contexts').then((r) => r.json()).then(setContexts);
+  }, []);
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger>{value || 'Context'}</SelectTrigger>
+      <SelectContent>
+        {contexts.map((c) => (
+          <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/AccessControlUI/src/components/DataTable.tsx
+++ b/AccessControlUI/src/components/DataTable.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import { Table, Tbody, Tr, Th, Td } from './ui/table';
+
+export interface Column<T> {
+  header: string;
+  accessor: (row: T) => ReactNode;
+}
+
+export function DataTable<T>({ columns, data }: { columns: Column<T>[]; data: T[] }) {
+  return (
+    <Table>
+      <Tbody>
+        <tr>
+          {columns.map((col) => (
+            <Th key={col.header}>{col.header}</Th>
+          ))}
+        </tr>
+        {data.map((row, i) => (
+          <Tr key={i}>
+            {columns.map((col) => (
+              <Td key={col.header}>{col.accessor(row)}</Td>
+            ))}
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+}

--- a/AccessControlUI/src/components/EvaluatePanel.tsx
+++ b/AccessControlUI/src/components/EvaluatePanel.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import { Card } from './ui/card';
+
+export function EvaluatePanel({ children }: { children: ReactNode }) {
+  return <Card className="p-4 space-y-2">{children}</Card>;
+}

--- a/AccessControlUI/src/components/abac/AbacEditor.tsx
+++ b/AccessControlUI/src/components/abac/AbacEditor.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
+import PoliciesTable from './PoliciesTable';
+import EvaluateAccess from './EvaluateAccess';
+
+export default function AbacEditor() {
+  const [tab, setTab] = useState('policies');
+  return (
+    <Tabs value={tab} onValueChange={setTab} className="w-full">
+      <TabsList className="mb-2">
+        <TabsTrigger value="policies">Policies</TabsTrigger>
+        <TabsTrigger value="evaluate">Evaluate</TabsTrigger>
+      </TabsList>
+      <TabsContent value="policies"><PoliciesTable /></TabsContent>
+      <TabsContent value="evaluate"><EvaluateAccess /></TabsContent>
+    </Tabs>
+  );
+}

--- a/AccessControlUI/src/components/abac/EvaluateAccess.tsx
+++ b/AccessControlUI/src/components/abac/EvaluateAccess.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { EvaluatePanel } from '../EvaluatePanel';
+
+export default function EvaluateAccess() {
+  const [result, setResult] = useState<string | null>(null);
+  const [form, setForm] = useState({ user: '', action: '', resource: '' });
+
+  const evaluate = async () => {
+    const rbac = await fetch(`/api/users/${form.user}/effective-permissions`).then((r) => r.json());
+    const abac = await fetch('/api/policies/evaluate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: form.user, action: form.action, resource: form.resource, attrs: {} }),
+    }).then((r) => r.json());
+    const allowed = rbac.includes(form.action) && abac === true;
+    setResult(allowed ? 'ALLOW' : 'DENY');
+  };
+
+  return (
+    <EvaluatePanel>
+      <Input placeholder="User" value={form.user} onChange={(e) => setForm({ ...form, user: e.target.value })} />
+      <Input placeholder="Action" value={form.action} onChange={(e) => setForm({ ...form, action: e.target.value })} />
+      <Input placeholder="Resource" value={form.resource} onChange={(e) => setForm({ ...form, resource: e.target.value })} />
+      <Button onClick={evaluate}>Evaluate</Button>
+      {result && <div className="font-bold">{result}</div>}
+    </EvaluatePanel>
+  );
+}

--- a/AccessControlUI/src/components/abac/PoliciesTable.tsx
+++ b/AccessControlUI/src/components/abac/PoliciesTable.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { DataTable, Column } from '../DataTable';
+import { Button } from '../ui/button';
+
+interface Policy {
+  id: string;
+  action: string;
+  resource: string;
+  effect: string;
+  condition: string;
+}
+
+export default function PoliciesTable() {
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  useEffect(() => {
+    fetch('/api/policies').then((r) => r.json()).then(setPolicies);
+  }, []);
+
+  const columns: Column<Policy>[] = [
+    { header: 'Action', accessor: (p) => p.action },
+    { header: 'Resource', accessor: (p) => p.resource },
+    { header: 'Effect', accessor: (p) => p.effect },
+    { header: 'Condition', accessor: (p) => p.condition },
+    { header: 'Actions', accessor: () => <Button size="sm">Edit</Button> },
+  ];
+
+  return <DataTable columns={columns} data={policies} />;
+}

--- a/AccessControlUI/src/components/rbac/Assignments.tsx
+++ b/AccessControlUI/src/components/rbac/Assignments.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import { Select, SelectTrigger, SelectContent, SelectItem } from '../ui/select';
+
+export default function Assignments() {
+  const [userId, setUserId] = useState('');
+  return (
+    <div className="space-y-2">
+      <Select value={userId} onValueChange={setUserId}>
+        <SelectTrigger>{userId || 'Select User'}</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="1">User 1</SelectItem>
+        </SelectContent>
+      </Select>
+      <Button>Assign</Button>
+    </div>
+  );
+}

--- a/AccessControlUI/src/components/rbac/EffectivePermissions.tsx
+++ b/AccessControlUI/src/components/rbac/EffectivePermissions.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+
+interface EffectivePermission {
+  key: string;
+  source: string;
+}
+
+export default function EffectivePermissions() {
+  const [perms, setPerms] = useState<EffectivePermission[]>([]);
+  const [userId, setUserId] = useState('');
+
+  const load = () => {
+    fetch(`/api/users/${userId}/effective-permissions`).then((r) => r.json()).then(setPerms);
+  };
+
+  return (
+    <div className="space-y-2">
+      <input className="border p-1" value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="User ID" />
+      <Button onClick={load}>Load</Button>
+      <div className="flex flex-wrap gap-2">
+        {perms.map((p) => (
+          <Badge key={p.key} variant={p.source === 'deny' ? 'destructive' : 'default'}>
+            {p.key} ({p.source})
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/AccessControlUI/src/components/rbac/PermissionsTable.tsx
+++ b/AccessControlUI/src/components/rbac/PermissionsTable.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { DataTable, Column } from '../DataTable';
+import { Button } from '../ui/button';
+
+interface Permission {
+  id: string;
+  key: string;
+  description: string;
+  contextScope: string;
+}
+
+export default function PermissionsTable() {
+  const [perms, setPerms] = useState<Permission[]>([]);
+  useEffect(() => {
+    fetch('/api/permissions').then((r) => r.json()).then(setPerms);
+  }, []);
+
+  const columns: Column<Permission>[] = [
+    { header: 'Key', accessor: (p) => p.key },
+    { header: 'Description', accessor: (p) => p.description },
+    { header: 'Scope', accessor: (p) => p.contextScope },
+    { header: 'Actions', accessor: () => <Button size="sm">Edit</Button> },
+  ];
+
+  return <DataTable columns={columns} data={perms} />;
+}

--- a/AccessControlUI/src/components/rbac/RbacEditor.tsx
+++ b/AccessControlUI/src/components/rbac/RbacEditor.tsx
@@ -1,0 +1,27 @@
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
+import RolesTable from './RolesTable';
+import PermissionsTable from './PermissionsTable';
+import UsersTable from './UsersTable';
+import Assignments from './Assignments';
+import EffectivePermissions from './EffectivePermissions';
+import { useState } from 'react';
+
+export default function RbacEditor() {
+  const [tab, setTab] = useState('roles');
+  return (
+    <Tabs value={tab} onValueChange={setTab} className="w-full">
+      <TabsList className="mb-2">
+        <TabsTrigger value="roles">Roles</TabsTrigger>
+        <TabsTrigger value="permissions">Permissions</TabsTrigger>
+        <TabsTrigger value="users">Users</TabsTrigger>
+        <TabsTrigger value="assignments">Assignments</TabsTrigger>
+        <TabsTrigger value="effective">Effective</TabsTrigger>
+      </TabsList>
+      <TabsContent value="roles"><RolesTable /></TabsContent>
+      <TabsContent value="permissions"><PermissionsTable /></TabsContent>
+      <TabsContent value="users"><UsersTable /></TabsContent>
+      <TabsContent value="assignments"><Assignments /></TabsContent>
+      <TabsContent value="effective"><EffectivePermissions /></TabsContent>
+    </Tabs>
+  );
+}

--- a/AccessControlUI/src/components/rbac/RolesTable.tsx
+++ b/AccessControlUI/src/components/rbac/RolesTable.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { DataTable, Column } from '../DataTable';
+import { Button } from '../ui/button';
+
+interface Role {
+  id: string;
+  name: string;
+  contextType: string;
+  permissions: string[];
+}
+
+export default function RolesTable() {
+  const [roles, setRoles] = useState<Role[]>([]);
+  useEffect(() => {
+    fetch('/api/roles').then((r) => r.json()).then(setRoles);
+  }, []);
+
+  const columns: Column<Role>[] = [
+    { header: 'Name', accessor: (r) => r.name },
+    { header: 'Context', accessor: (r) => r.contextType },
+    { header: '# Permissions', accessor: (r) => r.permissions.length },
+    { header: 'Actions', accessor: (r) => <Button size="sm">Edit</Button> },
+  ];
+
+  return <DataTable columns={columns} data={roles} />;
+}

--- a/AccessControlUI/src/components/rbac/UsersTable.tsx
+++ b/AccessControlUI/src/components/rbac/UsersTable.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { DataTable, Column } from '../DataTable';
+import { Button } from '../ui/button';
+
+interface User {
+  id: string;
+  email: string;
+  roles: string[];
+  permissions: string[];
+}
+
+export default function UsersTable() {
+  const [users, setUsers] = useState<User[]>([]);
+  useEffect(() => {
+    fetch('/api/users').then((r) => r.json()).then(setUsers);
+  }, []);
+
+  const columns: Column<User>[] = [
+    { header: 'Email', accessor: (u) => u.email },
+    { header: 'Roles', accessor: (u) => u.roles.join(', ') },
+    { header: 'Permissions', accessor: (u) => u.permissions.join(', ') },
+    { header: 'Actions', accessor: () => <Button size="sm">Manage</Button> },
+  ];
+
+  return <DataTable columns={columns} data={users} />;
+}

--- a/AccessControlUI/src/components/ui/badge.tsx
+++ b/AccessControlUI/src/components/ui/badge.tsx
@@ -1,0 +1,18 @@
+import { cn } from '../../lib/utils';
+
+interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'default' | 'destructive';
+}
+
+export function Badge({ className, variant = 'default', ...props }: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors',
+        variant === 'destructive' ? 'bg-red-500 text-white' : 'bg-muted text-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/AccessControlUI/src/components/ui/button.tsx
+++ b/AccessControlUI/src/components/ui/button.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:opacity-50 disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/AccessControlUI/src/components/ui/card.tsx
+++ b/AccessControlUI/src/components/ui/card.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...props} />
+));
+Card.displayName = 'Card';
+
+export { Card };

--- a/AccessControlUI/src/components/ui/input.tsx
+++ b/AccessControlUI/src/components/ui/input.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={cn('flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50', className)}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/AccessControlUI/src/components/ui/select.tsx
+++ b/AccessControlUI/src/components/ui/select.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+const Select = SelectPrimitive.Root;
+
+const SelectTrigger = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Trigger>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>>(
+  ({ className, ...props }, ref) => (
+    <SelectPrimitive.Trigger
+      ref={ref}
+      className={cn('flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm', className)}
+      {...props}
+    >
+      <SelectPrimitive.Value />
+      <SelectPrimitive.Icon>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+);
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectContent = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Content>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>>(
+  ({ className, children, ...props }, ref) => (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        className={cn('relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md', className)}
+        {...props}
+      >
+        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+);
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectItem = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Item>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>>(
+  ({ className, children, ...props }, ref) => (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn('relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground', className)}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+);
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+export { Select, SelectTrigger, SelectContent, SelectItem };

--- a/AccessControlUI/src/components/ui/table.tsx
+++ b/AccessControlUI/src/components/ui/table.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+  <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+));
+Table.displayName = 'Table';
+
+const Tbody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+);
+Tbody.displayName = 'Tbody';
+
+const Tr = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn('border-b transition-colors hover:bg-muted/50', className)} {...props} />
+));
+Tr.displayName = 'Tr';
+
+const Th = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn('h-10 px-2 text-left align-middle font-medium text-muted-foreground', className)}
+    {...props}
+  />
+));
+Th.displayName = 'Th';
+
+const Td = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn('p-2 align-middle', className)} {...props} />
+));
+Td.displayName = 'Td';
+
+export { Table, Tbody, Tr, Th, Td };

--- a/AccessControlUI/src/components/ui/tabs.tsx
+++ b/AccessControlUI/src/components/ui/tabs.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cn } from '../../lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<React.ElementRef<typeof TabsPrimitive.List>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.List
+      ref={ref}
+      className={cn('inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground', className)}
+      {...props}
+    />
+  )
+);
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Trigger>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Content>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn('mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2', className)}
+      {...props}
+    />
+  )
+);
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/AccessControlUI/src/index.css
+++ b/AccessControlUI/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --font-sans: 'Inter', sans-serif;
+}

--- a/AccessControlUI/src/lib/api.ts
+++ b/AccessControlUI/src/lib/api.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+export const api = axios.create({ baseURL: '/api' });

--- a/AccessControlUI/src/lib/utils.ts
+++ b/AccessControlUI/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/AccessControlUI/src/main.tsx
+++ b/AccessControlUI/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/AccessControlUI/tailwind.config.js
+++ b/AccessControlUI/tailwind.config.js
@@ -1,0 +1,15 @@
+import { fontFamily } from 'tailwindcss/defaultTheme';
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-sans)', ...fontFamily.sans],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/AccessControlUI/tsconfig.json
+++ b/AccessControlUI/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/AccessControlUI/vite.config.ts
+++ b/AccessControlUI/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold React+TypeScript Policy Manager UI using shadcn/ui
- add RBAC and ABAC editors with tables and evaluation panel
- configure Vite + Tailwind setup for Policy Manager app

## Testing
- `npm test` *(fails: The table `main.UserPermission` does not exist in the current database)*
- `npm run test:minimal` *(fails: The table `main.UserPermission` does not exist in the current database)*

------
https://chatgpt.com/codex/tasks/task_e_68a9331662e4832aab3f8311887b4f4c